### PR TITLE
Quick Deploy Glob Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Pros:
 Cons:
 
 - Untested on Windows
-- Does not work with globs `(SuiteScripts/*)` in deploy.xml
 
 ### ToDo
 

--- a/package.json
+++ b/package.json
@@ -1,360 +1,355 @@
 {
-	"name": "netsuitesdf",
-	"displayName": "NetSuiteSDF",
-	"description": "Plugin to integrate NetSuite SDF CLI",
-	"version": "0.7.1",
-	"publisher": "christopherwxyz",
-	"license": "MIT",
-	"repository": "https://github.com/christopherwxyz/NetSuiteSDF",
-	"engines": {
-		"vscode": "^1.35.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"icon": "img/icon.png",
-	"galleryBanner": {
-		"color": "#C80000",
-		"theme": "dark"
-	},
-	"activationEvents": [
-		"workspaceContains:**/.sdf",
-		"workspaceContains:**/.sdfcli.json",
-		"onCommand:extension.addDependencies",
-		"onCommand:extension.deploy",
-		"onCommand:extension.importBundle",
-		"onCommand:extension.importFiles",
-		"onCommand:extension.importObjects",
-		"onCommand:extension.issueToken",
-		"onCommand:extension.listBundles",
-		"onCommand:extension.listFiles",
-		"onCommand:extension.listMissingDependencies",
-		"onCommand:extension.listObjects",
-		"onCommand:extension.preview",
-		"onCommand:extension.refreshConfig",
-		"onCommand:extension.removeFolders",
-		"onCommand:extension.resetPassword",
-		"onCommand:extension.revokeToken",
-		"onCommand:extension.saveToken",
-		"onCommand:extension.selectEnvironment",
-		"onCommand:extension.sync",
-		"onCommand:extension.update",
-		"onCommand:extension.updateCustomRecordsWithInstances",
-		"onCommand:extension.validate"
-	],
-	"main": "./dist/extension",
-	"contributes": {
-		"configuration": {
-			"type": "object",
-			"title": "NetSuiteSDF",
-			"properties": {
-				"netsuitesdf.useQuickDeploy": {
-					"type": "boolean",
-					"default": true,
-					"description": "Enable Quick Deployments"
-				}
-			}
-		},
-		"views": {
-			"explorer": [
-				{
-					"id": "netsuitesdf",
-					"name": "NetSuiteSDF"
-				}
-			]
-		},
-		"keybindings": [
-			{
-				"command": "extension.addDependencies",
-				"key": "ctrl+; a",
-				"mac": "cmd+; a"
-			},
-			{
-				"command": "extension.addFileToDeploy",
-				"key": "ctrl+; shift+=",
-				"mac": "cmd+; shift+="
-			},
-			{
-				"command": "extension.deploy",
-				"key": "ctrl+; d",
-				"mac": "cmd+; d"
-			},
-			{
-				"command": "extension.importBundle",
-				"key": "ctrl+; shift+b",
-				"mac": "cmd+; shift+b"
-			},
-			{
-				"command": "extension.importFiles",
-				"key": "ctrl+; shift+f",
-				"mac": "cmd+; shift+f"
-			},
-			{
-				"command": "extension.importObjects",
-				"key": "ctrl+; shift+o",
-				"mac": "cmd+; shift+o"
-			},
-			{
-				"command": "extension.issueToken",
-				"key": "ctrl+; t",
-				"mac": "cmd+; t"
-			},
-			{
-				"command": "extension.listBundles",
-				"key": "ctrl+; b",
-				"mac": "cmd+; b"
-			},
-			{
-				"command": "extension.listConfiguration",
-				"key": "ctrl+; c",
-				"mac": "cmd+; c"
-			},
-			{
-				"command": "extension.listFiles",
-				"key": "ctrl+; f",
-				"mac": "cmd+; f"
-			},
-			{
-				"command": "extension.listMissingDependencies",
-				"key": "ctrl+; m",
-				"mac": "cmd+; m"
-			},
-			{
-				"command": "extension.listObjects",
-				"key": "ctrl+; o",
-				"mac": "cmd+; o"
-			},
-			{
-				"command": "extension.preview",
-				"key": "ctrl+; p",
-				"mac": "cmd+; p"
-			},
-			{
-				"command": "extension.refreshConfig",
-				"key": "ctrl+; r",
-				"mac": "cmd+; r"
-			},
-			{
-				"command": "extension.revokeToken",
-				"key": "ctrl+; shift+r",
-				"mac": "cmd+; shift+r"
-			},
-			{
-				"command": "extension.saveToken",
-				"key": "ctrl+; shift+t",
-				"mac": "cmd+; shift+t"
-			},
-			{
-				"command": "extension.selectEnvironment",
-				"key": "ctrl+; s",
-				"mac": "cmd+; s"
-			},
-			{
-				"command": "extension.update",
-				"key": "ctrl+; u",
-				"mac": "cmd+; u"
-			},
-			{
-				"command": "extension.updateCustomRecordWithInstances",
-				"key": "ctrl+; shift+u",
-				"mac": "cmd+; shift+u"
-			},
-			{
-				"command": "extension.validate",
-				"key": "ctrl+; v",
-				"mac": "cmd+; v"
-			},
-			{
-				"command": "extension.resetPassword",
-				"key": "ctrl+; shift+p",
-				"mac": "cmd+; shift+p"
-			}
-		],
-		"commands": [
-			{
-				"command": "extension.addDependencies",
-				"title": "Add Dependencies to Manifest",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.addFileToDeploy",
-				"title": "Add current/selected file to deploy.xml",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.deploy",
-				"title": "Deploy to Account",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.importFolder",
-				"title": "Import Folder",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.importBundle",
-				"title": "Import Bundle",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.importFiles",
-				"title": "Import Files",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.importObjects",
-				"title": "Import Objects",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.issueToken",
-				"title": "Issue Token",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.listBundles",
-				"title": "List Bundles",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.listConfiguration",
-				"title": "List Configuration",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.listFiles",
-				"title": "List Files",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.listMissingDependencies",
-				"title": "List Missing Dependencies",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.listObjects",
-				"title": "List Objects",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.preview",
-				"title": "Preview",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.refreshConfig",
-				"title": "Refresh Config",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.removeFolders",
-				"title": "Remove folders",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.revokeToken",
-				"title": "Revoke Token",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.saveToken",
-				"title": "Save Token",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.selectEnvironment",
-				"title": "Select Environment",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.sync",
-				"title": "Run Customization Sync",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.update",
-				"title": "Update",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.updateCustomRecordWithInstances",
-				"title": "Update Custom Record with Instances",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.validate",
-				"title": "Validate Project",
-				"category": "SDF"
-			},
-			{
-				"command": "extension.resetPassword",
-				"title": "Reset Password",
-				"category": "SDF"
-			}
-		],
-		"menus": {
-			"view/item/context": [
-				{
-					"command": "extension.importFolder",
-					"when": "view == netsuitesdf && viewItem == sdf-object-folder"
-				},
-				{
-					"command": "extension.importObjects",
-					"when": "view == netsuitesdf && viewItem == sdf-object"
-				},
-				{
-					"command": "extension.importFiles",
-					"when": "view == netsuitesdf && viewItem == sdf-file"
-				}
-			],
-			"explorer/context": [
-				{
-					"command": "extension.addFileToDeploy",
-					"group": "z_commands"
-				}
-			]
-		}
-	},
-	"scripts": {
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"test": "npm run compile && node ./node_modules/vscode/bin/test",
-		"vscode:prepublish": "webpack --mode production",
-		"webpack": "webpack --mode development",
-		"webpack-dev": "webpack --mode development --watch",
-		"test-compile": "tsc -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install"
-	},
-	"dependencies": {
-		"bluebird": "^3.5.3",
-		"fs-extra": "^7.0.1",
-		"fstream": "^1.0.12",
-		"glob": "^7.1.4",
-		"lodash": "^4.17.11",
-		"rimraf": "^2.6.3",
-		"rxjs": "^5.5.10",
-		"spawn-rx": "~2.0.12",
-		"tar": "^4.4.10",
-		"tmp": "0.0.33",
-		"xml2js": "^0.4.19"
-	},
-	"devDependencies": {
-		"@types/fs-extra": "^7.0.0",
+  "name": "netsuitesdf",
+  "displayName": "NetSuiteSDF",
+  "description": "Plugin to integrate NetSuite SDF CLI",
+  "version": "0.7.1",
+  "publisher": "christopherwxyz",
+  "license": "MIT",
+  "repository": "https://github.com/christopherwxyz/NetSuiteSDF",
+  "engines": {
+    "vscode": "^1.35.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "icon": "img/icon.png",
+  "galleryBanner": {
+    "color": "#C80000",
+    "theme": "dark"
+  },
+  "activationEvents": [
+    "workspaceContains:**/.sdf",
+    "workspaceContains:**/.sdfcli.json",
+    "onCommand:extension.addDependencies",
+    "onCommand:extension.deploy",
+    "onCommand:extension.importBundle",
+    "onCommand:extension.importFiles",
+    "onCommand:extension.importObjects",
+    "onCommand:extension.issueToken",
+    "onCommand:extension.listBundles",
+    "onCommand:extension.listFiles",
+    "onCommand:extension.listMissingDependencies",
+    "onCommand:extension.listObjects",
+    "onCommand:extension.preview",
+    "onCommand:extension.refreshConfig",
+    "onCommand:extension.removeFolders",
+    "onCommand:extension.resetPassword",
+    "onCommand:extension.revokeToken",
+    "onCommand:extension.saveToken",
+    "onCommand:extension.selectEnvironment",
+    "onCommand:extension.sync",
+    "onCommand:extension.update",
+    "onCommand:extension.updateCustomRecordsWithInstances",
+    "onCommand:extension.validate"
+  ],
+  "main": "./dist/extension",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "NetSuiteSDF",
+      "properties": {
+        "netsuitesdf.useQuickDeploy": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Quick Deployments"
+        }
+      }
+    },
+    "views": {
+      "explorer": [
+        {
+          "id": "netsuitesdf",
+          "name": "NetSuiteSDF"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "extension.addDependencies",
+        "key": "ctrl+; a",
+        "mac": "cmd+; a"
+      },
+      {
+        "command": "extension.addFileToDeploy",
+        "key": "ctrl+; shift+=",
+        "mac": "cmd+; shift+="
+      },
+      {
+        "command": "extension.deploy",
+        "key": "ctrl+; d",
+        "mac": "cmd+; d"
+      },
+      {
+        "command": "extension.importBundle",
+        "key": "ctrl+; shift+b",
+        "mac": "cmd+; shift+b"
+      },
+      {
+        "command": "extension.importFiles",
+        "key": "ctrl+; shift+f",
+        "mac": "cmd+; shift+f"
+      },
+      {
+        "command": "extension.importObjects",
+        "key": "ctrl+; shift+o",
+        "mac": "cmd+; shift+o"
+      },
+      {
+        "command": "extension.issueToken",
+        "key": "ctrl+; t",
+        "mac": "cmd+; t"
+      },
+      {
+        "command": "extension.listBundles",
+        "key": "ctrl+; b",
+        "mac": "cmd+; b"
+      },
+      {
+        "command": "extension.listConfiguration",
+        "key": "ctrl+; c",
+        "mac": "cmd+; c"
+      },
+      {
+        "command": "extension.listFiles",
+        "key": "ctrl+; f",
+        "mac": "cmd+; f"
+      },
+      {
+        "command": "extension.listMissingDependencies",
+        "key": "ctrl+; m",
+        "mac": "cmd+; m"
+      },
+      {
+        "command": "extension.listObjects",
+        "key": "ctrl+; o",
+        "mac": "cmd+; o"
+      },
+      {
+        "command": "extension.preview",
+        "key": "ctrl+; p",
+        "mac": "cmd+; p"
+      },
+      {
+        "command": "extension.refreshConfig",
+        "key": "ctrl+; r",
+        "mac": "cmd+; r"
+      },
+      {
+        "command": "extension.revokeToken",
+        "key": "ctrl+; shift+r",
+        "mac": "cmd+; shift+r"
+      },
+      {
+        "command": "extension.saveToken",
+        "key": "ctrl+; shift+t",
+        "mac": "cmd+; shift+t"
+      },
+      {
+        "command": "extension.selectEnvironment",
+        "key": "ctrl+; s",
+        "mac": "cmd+; s"
+      },
+      {
+        "command": "extension.update",
+        "key": "ctrl+; u",
+        "mac": "cmd+; u"
+      },
+      {
+        "command": "extension.updateCustomRecordWithInstances",
+        "key": "ctrl+; shift+u",
+        "mac": "cmd+; shift+u"
+      },
+      {
+        "command": "extension.validate",
+        "key": "ctrl+; v",
+        "mac": "cmd+; v"
+      },
+      {
+        "command": "extension.resetPassword",
+        "key": "ctrl+; shift+p",
+        "mac": "cmd+; shift+p"
+      }
+    ],
+    "commands": [
+      {
+        "command": "extension.addDependencies",
+        "title": "Add Dependencies to Manifest",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.addFileToDeploy",
+        "title": "Add current/selected file to deploy.xml",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.deploy",
+        "title": "Deploy to Account",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.importFolder",
+        "title": "Import Folder",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.importBundle",
+        "title": "Import Bundle",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.importFiles",
+        "title": "Import Files",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.importObjects",
+        "title": "Import Objects",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.issueToken",
+        "title": "Issue Token",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.listBundles",
+        "title": "List Bundles",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.listConfiguration",
+        "title": "List Configuration",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.listFiles",
+        "title": "List Files",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.listMissingDependencies",
+        "title": "List Missing Dependencies",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.listObjects",
+        "title": "List Objects",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.preview",
+        "title": "Preview",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.refreshConfig",
+        "title": "Refresh Config",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.removeFolders",
+        "title": "Remove folders",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.revokeToken",
+        "title": "Revoke Token",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.saveToken",
+        "title": "Save Token",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.selectEnvironment",
+        "title": "Select Environment",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.sync",
+        "title": "Run Customization Sync",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.update",
+        "title": "Update",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.updateCustomRecordWithInstances",
+        "title": "Update Custom Record with Instances",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.validate",
+        "title": "Validate Project",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.resetPassword",
+        "title": "Reset Password",
+        "category": "SDF"
+      }
+    ],
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "extension.importFolder",
+          "when": "view == netsuitesdf && viewItem == sdf-object-folder"
+        },
+        {
+          "command": "extension.importObjects",
+          "when": "view == netsuitesdf && viewItem == sdf-object"
+        },
+        {
+          "command": "extension.importFiles",
+          "when": "view == netsuitesdf && viewItem == sdf-file"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "extension.addFileToDeploy",
+          "group": "z_commands"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "test": "npm run compile && node ./node_modules/vscode/bin/test",
+    "vscode:prepublish": "webpack --mode production",
+    "webpack": "webpack --mode development",
+    "webpack-dev": "webpack --mode development --watch",
+    "test-compile": "tsc -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.3",
+    "fs-extra": "^7.0.1",
+    "fstream": "^1.0.12",
+    "glob": "^7.1.4",
+    "lodash": "^4.17.11",
+    "rimraf": "^2.6.3",
+    "rxjs": "^5.5.10",
+    "spawn-rx": "~2.0.12",
+    "tar": "^4.4.10",
+    "tmp": "0.0.33",
+    "xml2js": "^0.4.19"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^7.0.0",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.122",
-		"@types/mocha": "^2.2.42",
-		"@types/node": "^12.0.4",
-		"@types/tmp": "0.0.34",
-		"@types/xml2js": "^0.4.3",
-		"ts-loader": "^5.3.3",
-		"typescript": "^3.5.1",
-		"vscode": "^1.1.34",
-		"webpack": "^4.29.6",
-		"webpack-cli": "^3.2.3"
-	},
-	"__metadata": {
-		"id": "3c84713c-2af2-4cad-b97c-7ddafa1b2058",
-		"publisherDisplayName": "christopherwxyz",
-		"publisherId": "94071eb8-367b-4648-a781-dac30d0de2ea"
-	}
+    "@types/mocha": "^2.2.42",
+    "@types/node": "^12.0.4",
+    "@types/tmp": "0.0.34",
+    "@types/xml2js": "^0.4.3",
+    "ts-loader": "^5.3.3",
+    "typescript": "^3.5.1",
+    "vscode": "^1.1.34",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.2.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,353 +1,360 @@
 {
-  "name": "netsuitesdf",
-  "displayName": "NetSuiteSDF",
-  "description": "Plugin to integrate NetSuite SDF CLI",
-  "version": "0.7.1",
-  "publisher": "christopherwxyz",
-  "license": "MIT",
-  "repository": "https://github.com/christopherwxyz/NetSuiteSDF",
-  "engines": {
-    "vscode": "^1.35.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "icon": "img/icon.png",
-  "galleryBanner": {
-    "color": "#C80000",
-    "theme": "dark"
-  },
-  "activationEvents": [
-    "workspaceContains:**/.sdf",
-    "workspaceContains:**/.sdfcli.json",
-    "onCommand:extension.addDependencies",
-    "onCommand:extension.deploy",
-    "onCommand:extension.importBundle",
-    "onCommand:extension.importFiles",
-    "onCommand:extension.importObjects",
-    "onCommand:extension.issueToken",
-    "onCommand:extension.listBundles",
-    "onCommand:extension.listFiles",
-    "onCommand:extension.listMissingDependencies",
-    "onCommand:extension.listObjects",
-    "onCommand:extension.preview",
-    "onCommand:extension.refreshConfig",
-    "onCommand:extension.removeFolders",
-    "onCommand:extension.resetPassword",
-    "onCommand:extension.revokeToken",
-    "onCommand:extension.saveToken",
-    "onCommand:extension.selectEnvironment",
-    "onCommand:extension.sync",
-    "onCommand:extension.update",
-    "onCommand:extension.updateCustomRecordsWithInstances",
-    "onCommand:extension.validate"
-  ],
-  "main": "./dist/extension",
-  "contributes": {
-    "configuration": {
-      "type": "object",
-      "title": "NetSuiteSDF",
-      "properties": {
-        "netsuitesdf.useQuickDeploy": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable Quick Deployments"
-        }
-      }
-    },
-    "views": {
-      "explorer": [
-        {
-          "id": "netsuitesdf",
-          "name": "NetSuiteSDF"
-        }
-      ]
-    },
-    "keybindings": [
-      {
-        "command": "extension.addDependencies",
-        "key": "ctrl+; a",
-        "mac": "cmd+; a"
-      },
-      {
-        "command": "extension.addFileToDeploy",
-        "key": "ctrl+; shift+=",
-        "mac": "cmd+; shift+="
-      },
-      {
-        "command": "extension.deploy",
-        "key": "ctrl+; d",
-        "mac": "cmd+; d"
-      },
-      {
-        "command": "extension.importBundle",
-        "key": "ctrl+; shift+b",
-        "mac": "cmd+; shift+b"
-      },
-      {
-        "command": "extension.importFiles",
-        "key": "ctrl+; shift+f",
-        "mac": "cmd+; shift+f"
-      },
-      {
-        "command": "extension.importObjects",
-        "key": "ctrl+; shift+o",
-        "mac": "cmd+; shift+o"
-      },
-      {
-        "command": "extension.issueToken",
-        "key": "ctrl+; t",
-        "mac": "cmd+; t"
-      },
-      {
-        "command": "extension.listBundles",
-        "key": "ctrl+; b",
-        "mac": "cmd+; b"
-      },
-      {
-        "command": "extension.listConfiguration",
-        "key": "ctrl+; c",
-        "mac": "cmd+; c"
-      },
-      {
-        "command": "extension.listFiles",
-        "key": "ctrl+; f",
-        "mac": "cmd+; f"
-      },
-      {
-        "command": "extension.listMissingDependencies",
-        "key": "ctrl+; m",
-        "mac": "cmd+; m"
-      },
-      {
-        "command": "extension.listObjects",
-        "key": "ctrl+; o",
-        "mac": "cmd+; o"
-      },
-      {
-        "command": "extension.preview",
-        "key": "ctrl+; p",
-        "mac": "cmd+; p"
-      },
-      {
-        "command": "extension.refreshConfig",
-        "key": "ctrl+; r",
-        "mac": "cmd+; r"
-      },
-      {
-        "command": "extension.revokeToken",
-        "key": "ctrl+; shift+r",
-        "mac": "cmd+; shift+r"
-      },
-      {
-        "command": "extension.saveToken",
-        "key": "ctrl+; shift+t",
-        "mac": "cmd+; shift+t"
-      },
-      {
-        "command": "extension.selectEnvironment",
-        "key": "ctrl+; s",
-        "mac": "cmd+; s"
-      },
-      {
-        "command": "extension.update",
-        "key": "ctrl+; u",
-        "mac": "cmd+; u"
-      },
-      {
-        "command": "extension.updateCustomRecordWithInstances",
-        "key": "ctrl+; shift+u",
-        "mac": "cmd+; shift+u"
-      },
-      {
-        "command": "extension.validate",
-        "key": "ctrl+; v",
-        "mac": "cmd+; v"
-      },
-      {
-        "command": "extension.resetPassword",
-        "key": "ctrl+; shift+p",
-        "mac": "cmd+; shift+p"
-      }
-    ],
-    "commands": [
-      {
-        "command": "extension.addDependencies",
-        "title": "Add Dependencies to Manifest",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.addFileToDeploy",
-        "title": "Add current/selected file to deploy.xml",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.deploy",
-        "title": "Deploy to Account",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.importFolder",
-        "title": "Import Folder",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.importBundle",
-        "title": "Import Bundle",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.importFiles",
-        "title": "Import Files",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.importObjects",
-        "title": "Import Objects",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.issueToken",
-        "title": "Issue Token",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.listBundles",
-        "title": "List Bundles",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.listConfiguration",
-        "title": "List Configuration",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.listFiles",
-        "title": "List Files",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.listMissingDependencies",
-        "title": "List Missing Dependencies",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.listObjects",
-        "title": "List Objects",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.preview",
-        "title": "Preview",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.refreshConfig",
-        "title": "Refresh Config",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.removeFolders",
-        "title": "Remove folders",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.revokeToken",
-        "title": "Revoke Token",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.saveToken",
-        "title": "Save Token",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.selectEnvironment",
-        "title": "Select Environment",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.sync",
-        "title": "Run Customization Sync",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.update",
-        "title": "Update",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.updateCustomRecordWithInstances",
-        "title": "Update Custom Record with Instances",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.validate",
-        "title": "Validate Project",
-        "category": "SDF"
-      },
-      {
-        "command": "extension.resetPassword",
-        "title": "Reset Password",
-        "category": "SDF"
-      }
-    ],
-    "menus": {
-      "view/item/context": [
-        {
-          "command": "extension.importFolder",
-          "when": "view == netsuitesdf && viewItem == sdf-object-folder"
-        },
-        {
-          "command": "extension.importObjects",
-          "when": "view == netsuitesdf && viewItem == sdf-object"
-        },
-        {
-          "command": "extension.importFiles",
-          "when": "view == netsuitesdf && viewItem == sdf-file"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "extension.addFileToDeploy",
-          "group": "z_commands"
-        }
-      ]
-    }
-  },
-  "scripts": {
-    "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
-    "test": "npm run compile && node ./node_modules/vscode/bin/test",
-    "vscode:prepublish": "webpack --mode production",
-    "webpack": "webpack --mode development",
-    "webpack-dev": "webpack --mode development --watch",
-    "test-compile": "tsc -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
-  },
-  "dependencies": {
-    "@types/lodash": "^4.14.122",
-    "bluebird": "^3.5.3",
-    "fs-extra": "^7.0.1",
-    "fstream": "^1.0.12",
-    "lodash": "^4.17.11",
-    "rimraf": "^2.6.3",
-    "rxjs": "^5.5.10",
-    "spawn-rx": "~2.0.12",
-    "tar": "^4.4.10",
-    "tmp": "0.0.33",
-    "xml2js": "^0.4.19"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^7.0.0",
-    "@types/mocha": "^2.2.42",
-    "@types/node": "^12.0.4",
-    "@types/tmp": "0.0.34",
-    "@types/xml2js": "^0.4.3",
-    "ts-loader": "^5.3.3",
-    "typescript": "^3.5.1",
-    "vscode": "^1.1.34",
-    "webpack": "^4.29.6",
-    "webpack-cli": "^3.2.3"
-  }
+	"name": "netsuitesdf",
+	"displayName": "NetSuiteSDF",
+	"description": "Plugin to integrate NetSuite SDF CLI",
+	"version": "0.7.1",
+	"publisher": "christopherwxyz",
+	"license": "MIT",
+	"repository": "https://github.com/christopherwxyz/NetSuiteSDF",
+	"engines": {
+		"vscode": "^1.35.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"icon": "img/icon.png",
+	"galleryBanner": {
+		"color": "#C80000",
+		"theme": "dark"
+	},
+	"activationEvents": [
+		"workspaceContains:**/.sdf",
+		"workspaceContains:**/.sdfcli.json",
+		"onCommand:extension.addDependencies",
+		"onCommand:extension.deploy",
+		"onCommand:extension.importBundle",
+		"onCommand:extension.importFiles",
+		"onCommand:extension.importObjects",
+		"onCommand:extension.issueToken",
+		"onCommand:extension.listBundles",
+		"onCommand:extension.listFiles",
+		"onCommand:extension.listMissingDependencies",
+		"onCommand:extension.listObjects",
+		"onCommand:extension.preview",
+		"onCommand:extension.refreshConfig",
+		"onCommand:extension.removeFolders",
+		"onCommand:extension.resetPassword",
+		"onCommand:extension.revokeToken",
+		"onCommand:extension.saveToken",
+		"onCommand:extension.selectEnvironment",
+		"onCommand:extension.sync",
+		"onCommand:extension.update",
+		"onCommand:extension.updateCustomRecordsWithInstances",
+		"onCommand:extension.validate"
+	],
+	"main": "./dist/extension",
+	"contributes": {
+		"configuration": {
+			"type": "object",
+			"title": "NetSuiteSDF",
+			"properties": {
+				"netsuitesdf.useQuickDeploy": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable Quick Deployments"
+				}
+			}
+		},
+		"views": {
+			"explorer": [
+				{
+					"id": "netsuitesdf",
+					"name": "NetSuiteSDF"
+				}
+			]
+		},
+		"keybindings": [
+			{
+				"command": "extension.addDependencies",
+				"key": "ctrl+; a",
+				"mac": "cmd+; a"
+			},
+			{
+				"command": "extension.addFileToDeploy",
+				"key": "ctrl+; shift+=",
+				"mac": "cmd+; shift+="
+			},
+			{
+				"command": "extension.deploy",
+				"key": "ctrl+; d",
+				"mac": "cmd+; d"
+			},
+			{
+				"command": "extension.importBundle",
+				"key": "ctrl+; shift+b",
+				"mac": "cmd+; shift+b"
+			},
+			{
+				"command": "extension.importFiles",
+				"key": "ctrl+; shift+f",
+				"mac": "cmd+; shift+f"
+			},
+			{
+				"command": "extension.importObjects",
+				"key": "ctrl+; shift+o",
+				"mac": "cmd+; shift+o"
+			},
+			{
+				"command": "extension.issueToken",
+				"key": "ctrl+; t",
+				"mac": "cmd+; t"
+			},
+			{
+				"command": "extension.listBundles",
+				"key": "ctrl+; b",
+				"mac": "cmd+; b"
+			},
+			{
+				"command": "extension.listConfiguration",
+				"key": "ctrl+; c",
+				"mac": "cmd+; c"
+			},
+			{
+				"command": "extension.listFiles",
+				"key": "ctrl+; f",
+				"mac": "cmd+; f"
+			},
+			{
+				"command": "extension.listMissingDependencies",
+				"key": "ctrl+; m",
+				"mac": "cmd+; m"
+			},
+			{
+				"command": "extension.listObjects",
+				"key": "ctrl+; o",
+				"mac": "cmd+; o"
+			},
+			{
+				"command": "extension.preview",
+				"key": "ctrl+; p",
+				"mac": "cmd+; p"
+			},
+			{
+				"command": "extension.refreshConfig",
+				"key": "ctrl+; r",
+				"mac": "cmd+; r"
+			},
+			{
+				"command": "extension.revokeToken",
+				"key": "ctrl+; shift+r",
+				"mac": "cmd+; shift+r"
+			},
+			{
+				"command": "extension.saveToken",
+				"key": "ctrl+; shift+t",
+				"mac": "cmd+; shift+t"
+			},
+			{
+				"command": "extension.selectEnvironment",
+				"key": "ctrl+; s",
+				"mac": "cmd+; s"
+			},
+			{
+				"command": "extension.update",
+				"key": "ctrl+; u",
+				"mac": "cmd+; u"
+			},
+			{
+				"command": "extension.updateCustomRecordWithInstances",
+				"key": "ctrl+; shift+u",
+				"mac": "cmd+; shift+u"
+			},
+			{
+				"command": "extension.validate",
+				"key": "ctrl+; v",
+				"mac": "cmd+; v"
+			},
+			{
+				"command": "extension.resetPassword",
+				"key": "ctrl+; shift+p",
+				"mac": "cmd+; shift+p"
+			}
+		],
+		"commands": [
+			{
+				"command": "extension.addDependencies",
+				"title": "Add Dependencies to Manifest",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.addFileToDeploy",
+				"title": "Add current/selected file to deploy.xml",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.deploy",
+				"title": "Deploy to Account",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.importFolder",
+				"title": "Import Folder",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.importBundle",
+				"title": "Import Bundle",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.importFiles",
+				"title": "Import Files",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.importObjects",
+				"title": "Import Objects",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.issueToken",
+				"title": "Issue Token",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.listBundles",
+				"title": "List Bundles",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.listConfiguration",
+				"title": "List Configuration",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.listFiles",
+				"title": "List Files",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.listMissingDependencies",
+				"title": "List Missing Dependencies",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.listObjects",
+				"title": "List Objects",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.preview",
+				"title": "Preview",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.refreshConfig",
+				"title": "Refresh Config",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.removeFolders",
+				"title": "Remove folders",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.revokeToken",
+				"title": "Revoke Token",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.saveToken",
+				"title": "Save Token",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.selectEnvironment",
+				"title": "Select Environment",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.sync",
+				"title": "Run Customization Sync",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.update",
+				"title": "Update",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.updateCustomRecordWithInstances",
+				"title": "Update Custom Record with Instances",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.validate",
+				"title": "Validate Project",
+				"category": "SDF"
+			},
+			{
+				"command": "extension.resetPassword",
+				"title": "Reset Password",
+				"category": "SDF"
+			}
+		],
+		"menus": {
+			"view/item/context": [
+				{
+					"command": "extension.importFolder",
+					"when": "view == netsuitesdf && viewItem == sdf-object-folder"
+				},
+				{
+					"command": "extension.importObjects",
+					"when": "view == netsuitesdf && viewItem == sdf-object"
+				},
+				{
+					"command": "extension.importFiles",
+					"when": "view == netsuitesdf && viewItem == sdf-file"
+				}
+			],
+			"explorer/context": [
+				{
+					"command": "extension.addFileToDeploy",
+					"group": "z_commands"
+				}
+			]
+		}
+	},
+	"scripts": {
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"test": "npm run compile && node ./node_modules/vscode/bin/test",
+		"vscode:prepublish": "webpack --mode production",
+		"webpack": "webpack --mode development",
+		"webpack-dev": "webpack --mode development --watch",
+		"test-compile": "tsc -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
+	},
+	"dependencies": {
+		"@types/lodash": "^4.14.122",
+		"bluebird": "^3.5.3",
+		"fs-extra": "^7.0.1",
+		"fstream": "^1.0.12",
+		"glob": "^7.1.4",
+		"lodash": "^4.17.11",
+		"rimraf": "^2.6.3",
+		"rxjs": "^5.5.10",
+		"spawn-rx": "~2.0.12",
+		"tar": "^4.4.10",
+		"tmp": "0.0.33",
+		"xml2js": "^0.4.19"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^7.0.0",
+		"@types/glob": "^7.1.1",
+		"@types/mocha": "^2.2.42",
+		"@types/node": "^12.0.4",
+		"@types/tmp": "0.0.34",
+		"@types/xml2js": "^0.4.3",
+		"ts-loader": "^5.3.3",
+		"typescript": "^3.5.1",
+		"vscode": "^1.1.34",
+		"webpack": "^4.29.6",
+		"webpack-cli": "^3.2.3"
+	},
+	"__metadata": {
+		"id": "3c84713c-2af2-4cad-b97c-7ddafa1b2058",
+		"publisherDisplayName": "christopherwxyz",
+		"publisherId": "94071eb8-367b-4648-a781-dac30d0de2ea"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "netsuitesdf",
   "displayName": "NetSuiteSDF",
   "description": "Plugin to integrate NetSuite SDF CLI",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "christopherwxyz",
   "license": "MIT",
   "repository": "https://github.com/christopherwxyz/NetSuiteSDF",

--- a/package.json
+++ b/package.json
@@ -326,7 +326,6 @@
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"dependencies": {
-		"@types/lodash": "^4.14.122",
 		"bluebird": "^3.5.3",
 		"fs-extra": "^7.0.1",
 		"fstream": "^1.0.12",
@@ -341,7 +340,8 @@
 	},
 	"devDependencies": {
 		"@types/fs-extra": "^7.0.0",
-		"@types/glob": "^7.1.1",
+    "@types/glob": "^7.1.1",
+    "@types/lodash": "^4.14.122",
 		"@types/mocha": "^2.2.42",
 		"@types/node": "^12.0.4",
 		"@types/tmp": "0.0.34",

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -142,6 +142,7 @@ export class NetSuiteSDF {
     const files = _.get(deployJs, 'deploy.files[0].path', []);
     const objects = _.get(deployJs, 'deploy.objects[0].path', []);
     const allFiles = files.concat(objects).concat(['/deploy.xml', '/manifest.xml', '/.sdf']);
+    console.log('All File Paths', allFiles);
 
     this.tempDir = tmp.dirSync({ unsafeCleanup: true, keep: false });
     try {

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -3,8 +3,6 @@ import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as util from 'util';
-import { chdir } from 'process';
-import { ChildProcess } from 'child_process';
 
 import * as _ from 'lodash';
 import * as glob from 'glob';

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -544,7 +544,7 @@ export class NetSuiteSDF {
 
     let currentFile: string;
     if (context && context.fsPath) {
-      currentFile = context.fsPath;
+      currentFile = fs.lstatSync(context.fsPath).isDirectory() ? `${context.fsPath}${path.sep}*` : context.fsPath;
     } else {
       currentFile = vscode.window.activeTextEditor.document.fileName;
     }


### PR DESCRIPTION
Hey,

I've been using this more and more with my team and I'm liking the quick deploy feature, but we tend to use the glob patterns in our deploy file. So I thought I'd take a stab at adding support for it.

Essentially I'm resolving any glob patterns to the file paths they match before passing the whole list to your existing function that creates the temporary directory and moves the files. I also made it so that if you click "add current/selected file to deployment" on a folder instead of a file it will default the added file path as a glob pattern (i.e. SuiteScripts => FileCabinet/SuiteScripts/*).

I did test it with various combinations of glob patterns and regular file names and it seems to have worked for all of them. So feel free to give it a shot and let me know what you think.