### PR TITLE
Feature 1 - TypeScript to JavaScript file matching upon adding file to deploy.xml

### DIFF
--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -51,6 +51,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable Quick Deployments (BETA)"
+        },
+        "netsuitesdf.addMatchingJavascriptWhenAddingTypescriptToDeployXML": {
+          "type": "boolean",
+          "default": true,
+          "description": "When adding a TypeScript file to deploy.xml, its matching compiled JavaScript file will be added in its place."
         }
       }
     },

--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -319,7 +319,7 @@
       "explorer/context": [
         {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands"
+          "group": "z_commands@3"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable Quick Deployments"
+        },
+        "netsuitesdf.addMatchingJavascriptWhenAddingTypescriptToDeployXML": {
+          "type": "boolean",
+          "default": true,
+          "description": "When adding a TypeScript file to deploy.xml, its matching compiled JavaScript file will be added in its place."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
       "explorer/context": [
         {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands"
+          "group": "z_commands@3"
         }
       ]
     }

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -550,12 +550,13 @@ export class NetSuiteSDF {
     let config = vscode.workspace.getConfiguration('netsuitesdf');
     const addMatchingJSWhenAddingTSToDeployXML = config.get('addMatchingJavascriptWhenAddingTypescriptToDeployXML');
 
-    let isJavaScript = _.includes(currentFile, path.join(this.rootPath, '/FileCabinet/SuiteScripts')) && _.includes(currentFile, '.js');
+    const isFileInFileCabinet = _.includes(currentFile, path.join(this.rootPath, '/FileCabinet/SuiteScripts'));
+    let isJavaScript = isFileInFileCabinet && _.includes(currentFile, '.js');
     const isTypeScript = _.includes(currentFile, '.ts');
     const isObject = _.includes(currentFile, path.join(this.rootPath, '/Objects')) && _.includes(currentFile, '.xml');
     let matchedJavaScriptFile: string;
 
-    if (!isJavaScript && !isObject) {
+    if (!isFileInFileCabinet && !isJavaScript && !isObject) {
       if (isTypeScript && addMatchingJSWhenAddingTSToDeployXML) {
         const matchedJavaScriptFiles: string[] = [];
         const currentFileName = path.basename(currentFile);
@@ -603,7 +604,7 @@ export class NetSuiteSDF {
       }
     }
 
-    const xmlPath = isJavaScript ? 'deploy.files[0].path' : 'deploy.objects[0].path';
+    const xmlPath = isFileInFileCabinet || isJavaScript ? 'deploy.files[0].path' : 'deploy.objects[0].path';
     const relativePath = _.replace(currentFile, this.rootPath, '~').replace(/\\/gi, '/');
 
     const deployXmlExists = await this.fileExists(deployPath);


### PR DESCRIPTION
Hey!
Sharing another useful feature for us. With this, when attempting to add a TypeScript file to deploy.xml, this will look for the matching, compiled JavaScript file in the FileCabinet/SuiteScripts folder and add that to deploy.xml instead. Also added a setting for this in the extension settings so it can be either enabled or disabled, in case you actually want to deploy your TypeScript files to NS.