### PR TITLE
Feature 2 - Create/Reset deploy.xml file via right-click in VSCode File Explorer

### DIFF
--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -69,7 +69,7 @@
         "mac": "cmd+; a"
       },
       {
-        "command": "extension.resetDeploy",
+        "command": "extension.createResetDeploy",
         "key": "ctrl+; shift+-",
         "mac": "cmd+; shift+-"
       },
@@ -181,8 +181,8 @@
         "category": "SDF"
       },
       {
-        "command": "extension.resetDeploy",
-        "title": "Reset deploy.xml",
+        "command": "extension.createResetDeploy",
+        "title": "Create/Reset deploy.xml",
         "category": "SDF"
       },
       {
@@ -323,7 +323,7 @@
       ],
       "explorer/context": [
         {
-          "command": "extension.resetDeploy",
+          "command": "extension.createResetDeploy",
           "group": "z_commands@1"
         },
         {

--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -69,6 +69,11 @@
         "mac": "cmd+; a"
       },
       {
+        "command": "extension.resetDeploy",
+        "key": "ctrl+; shift+-",
+        "mac": "cmd+; shift+-"
+      },
+      {
         "command": "extension.addFileToDeploy",
         "key": "ctrl+; shift+=",
         "mac": "cmd+; shift+="
@@ -173,6 +178,11 @@
       {
         "command": "extension.addDependencies",
         "title": "Add Dependencies to Manifest",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.resetDeploy",
+        "title": "Reset deploy.xml",
         "category": "SDF"
       },
       {
@@ -313,8 +323,12 @@
       ],
       "explorer/context": [
         {
+          "command": "extension.resetDeploy",
+          "group": "z_commands@1"
+        },
+        {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands"
+          "group": "z_commands@2"
         }
       ]
     }

--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -328,7 +328,7 @@
         },
         {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands@2"
+          "group": "z_commands@3"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
         "mac": "cmd+; a"
       },
       {
+        "command": "extension.resetDeploy",
+        "key": "ctrl+; shift+-",
+        "mac": "cmd+; shift+-"
+      },
+      {
         "command": "extension.addFileToDeploy",
         "key": "ctrl+; shift+=",
         "mac": "cmd+; shift+="
@@ -174,6 +179,11 @@
       {
         "command": "extension.addDependencies",
         "title": "Add Dependencies to Manifest",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.resetDeploy",
+        "title": "Reset deploy.xml",
         "category": "SDF"
       },
       {
@@ -309,8 +319,12 @@
       ],
       "explorer/context": [
         {
+          "command": "extension.resetDeploy",
+          "group": "z_commands@1"
+        },
+        {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands"
+          "group": "z_commands@2"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
         },
         {
           "command": "extension.addFileToDeploy",
-          "group": "z_commands@2"
+          "group": "z_commands@3"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "mac": "cmd+; a"
       },
       {
-        "command": "extension.resetDeploy",
+        "command": "extension.createResetDeploy",
         "key": "ctrl+; shift+-",
         "mac": "cmd+; shift+-"
       },
@@ -182,8 +182,8 @@
         "category": "SDF"
       },
       {
-        "command": "extension.resetDeploy",
-        "title": "Reset deploy.xml",
+        "command": "extension.createResetDeploy",
+        "title": "Create/Reset deploy.xml",
         "category": "SDF"
       },
       {
@@ -319,7 +319,7 @@
       ],
       "explorer/context": [
         {
-          "command": "extension.resetDeploy",
+          "command": "extension.createResetDeploy",
           "group": "z_commands@1"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,9 +26,9 @@ export async function activate(context: vscode.ExtensionContext) {
     'extension.addDependencies',
     netsuiteSdf.addDependencies.bind(netsuiteSdf)
   );
-  let resetDeploy = vscode.commands.registerCommand(
-    'extension.resetDeploy',
-    netsuiteSdf.resetDeploy.bind(netsuiteSdf)
+  let createResetDeploy = vscode.commands.registerCommand(
+    'extension.createResetDeploy',
+    netsuiteSdf.createResetDeploy.bind(netsuiteSdf)
   );
   let addFileToDeploy = vscode.commands.registerCommand(
     'extension.addFileToDeploy',
@@ -93,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // context.subscriptions.push(refresh);
 
   context.subscriptions.push(addDependencies);
-  context.subscriptions.push(resetDeploy);
+  context.subscriptions.push(createResetDeploy);
   context.subscriptions.push(addFileToDeploy);
   context.subscriptions.push(deploy);
   context.subscriptions.push(importBundle);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,10 @@ export async function activate(context: vscode.ExtensionContext) {
     'extension.addDependencies',
     netsuiteSdf.addDependencies.bind(netsuiteSdf)
   );
+  let resetDeploy = vscode.commands.registerCommand(
+    'extension.resetDeploy',
+    netsuiteSdf.resetDeploy.bind(netsuiteSdf)
+  );
   let addFileToDeploy = vscode.commands.registerCommand(
     'extension.addFileToDeploy',
     netsuiteSdf.addFileToDeploy.bind(netsuiteSdf)
@@ -89,6 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // context.subscriptions.push(refresh);
 
   context.subscriptions.push(addDependencies);
+  context.subscriptions.push(resetDeploy);
   context.subscriptions.push(addFileToDeploy);
   context.subscriptions.push(deploy);
   context.subscriptions.push(importBundle);

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -532,6 +532,12 @@ export class NetSuiteSDF {
   /** Extension Commands **/
   /************************/
 
+  async resetDeploy(context?: any) {
+    await this.getConfig();
+    this.setDefaultDeployXml();
+    vscode.window.showInformationMessage('Reset deploy.xml.');
+  }
+
   async addFileToDeploy(context?: any) {
     if (context && context.scheme !== 'file') {
       vscode.window.showWarningMessage(`Unknown file type '${context.scheme}' to add to deploy.xml`);

--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -532,7 +532,7 @@ export class NetSuiteSDF {
   /** Extension Commands **/
   /************************/
 
-  async resetDeploy(context?: any) {
+  async createResetDeploy(context?: any) {
     await this.getConfig();
     this.setDefaultDeployXml();
     vscode.window.showInformationMessage('Reset deploy.xml.');


### PR DESCRIPTION
Hey!
We here at BKDV get a lot of use out of your extension, so I thought I'd make a few feature updates and share. This is just a simple Create/Reset deploy.xml feature, accessible via right-click in the File Explorer pane. I find myself constantly opening deploy.xml and clearing out the files and objects listed there, so hopefully somewhat of a timesaver.