### PR TITLE
Feature 3 - Add Backup/Restore Deploy.xml feature

### DIFF
--- a/package.2019.1.json
+++ b/package.2019.1.json
@@ -56,6 +56,11 @@
           "type": "boolean",
           "default": true,
           "description": "When adding a TypeScript file to deploy.xml, its matching compiled JavaScript file will be added in its place."
+        },
+        "netsuitesdf.onBackupAutoCreateNewDeployXML": {
+          "type": "boolean",
+          "default": true,
+          "description": "When performing a backup of deploy.xml, automatically create a new, empty deploy.xml."
         }
       }
     },
@@ -188,6 +193,11 @@
       {
         "command": "extension.createResetDeploy",
         "title": "Create/Reset deploy.xml",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.backupRestoreDeploy",
+        "title": "Backup/Restore deploy.xml",
         "category": "SDF"
       },
       {
@@ -330,6 +340,11 @@
         {
           "command": "extension.createResetDeploy",
           "group": "z_commands@1"
+        },
+        {
+          "when": "resourceLangId == xml && resourceFilename =~ /(.+\\.)?deploy.xml/",
+          "command": "extension.backupRestoreDeploy",
+          "group": "z_commands@2"
         },
         {
           "command": "extension.addFileToDeploy",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
           "type": "boolean",
           "default": true,
           "description": "When adding a TypeScript file to deploy.xml, its matching compiled JavaScript file will be added in its place."
+        },
+        "netsuitesdf.onBackupAutoCreateNewDeployXML": {
+          "type": "boolean",
+          "default": true,
+          "description": "When performing a backup of deploy.xml, automatically create a new, empty deploy.xml."
         }
       }
     },
@@ -189,6 +194,11 @@
       {
         "command": "extension.createResetDeploy",
         "title": "Create/Reset deploy.xml",
+        "category": "SDF"
+      },
+      {
+        "command": "extension.backupRestoreDeploy",
+        "title": "Backup/Restore deploy.xml",
         "category": "SDF"
       },
       {
@@ -326,6 +336,11 @@
         {
           "command": "extension.createResetDeploy",
           "group": "z_commands@1"
+        },
+        {
+          "when": "resourceLangId == xml && resourceFilename =~ /(.+\\.)?deploy.xml/",
+          "command": "extension.backupRestoreDeploy",
+          "group": "z_commands@2"
         },
         {
           "command": "extension.addFileToDeploy",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,10 @@ export async function activate(context: vscode.ExtensionContext) {
     'extension.createResetDeploy',
     netsuiteSdf.createResetDeploy.bind(netsuiteSdf)
   );
+  let backupRestoreDeploy = vscode.commands.registerCommand(
+    'extension.backupRestoreDeploy',
+    netsuiteSdf.backupRestoreDeploy.bind(netsuiteSdf)
+  );
   let addFileToDeploy = vscode.commands.registerCommand(
     'extension.addFileToDeploy',
     netsuiteSdf.addFileToDeploy.bind(netsuiteSdf)
@@ -94,6 +98,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(addDependencies);
   context.subscriptions.push(createResetDeploy);
+  context.subscriptions.push(backupRestoreDeploy);
   context.subscriptions.push(addFileToDeploy);
   context.subscriptions.push(deploy);
   context.subscriptions.push(importBundle);


### PR DESCRIPTION
Hey! Thanks for the previous PR merges...here's another!

This implements a backup and restore feature for `deploy.xml`. After right-clicking on `deploy.xml` and selecting **Backup/Restore deploy.xml**, you are prompted to enter a prefix for the backup file; enter a prefix or leave the input empty to use the current date and time as the prefix, and press **Enter**. The `deploy.xml` file will be renamed to `prefix.deploy.xml` and a new `deploy.xml` file will or will not be generated based on the **On Backup Auto Create New Deploy XML** extension setting.

To restore a backup, right-click on any `*.deploy.xml` file and again select **Backup/Restore deploy.xml**. If a `deploy.xml` file currently exists, you'll be prompted to type **OK** to restore the backup over it.

Gotten quite a bit of use out of this over the last few weeks. Hope you find it useful!