### PR TITLE
Update DeployXML Backup and Restore Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,15 @@
           "default": true,
           "description": "When adding a TypeScript file to deploy.xml, its matching compiled JavaScript file will be added in its place."
         },
-        "netsuitesdf.onBackupAutoCreateNewDeployXML": {
+        "netsuitesdf.onBackupResetDeployXML": {
           "type": "boolean",
           "default": true,
-          "description": "When performing a backup of deploy.xml, automatically create a new, empty deploy.xml."
+          "description": "After creating a backup of deploy.xml, reset deploy.xml."
+        },
+        "netsuitesdf.onRestoreDeleteBackupDeployXML": {
+          "type": "boolean",
+          "default": true,
+          "description": "After restoring a backup of deploy.xml, delete the backup of deploy.xml."
         }
       }
     },


### PR DESCRIPTION
Hello!

Submitting a PR to add some options to the deploy.xml backup and restore process. After daily use of this extension for quite some time, I found these updates to be quite helpful in my workflow.

- **Extension Settings > On Backup Reset Deploy XML**: If checked, after a backup of deploy.xml is created, deploy.xml is reset (like it currently functions). If unchecked, deploy.xml retains its contents and is not reset.
- **Extension Settings > On Restore Delete Backup Deploy XML**: New setting. If checked, after restoring a backup of deploy.xml, the backup is deleted (like it currently functions). If unchecked, the backup is not deleted.

Thanks!